### PR TITLE
fixed bug that prevented display of h/phone check in default language

### DIFF
--- a/HeadphoneCheck/HeadphoneCheck-modified.js
+++ b/HeadphoneCheck/HeadphoneCheck-modified.js
@@ -246,7 +246,7 @@ Contact Ray Gonzalez raygon@mit.edu or Kevin J. P. Woods kwoods@mit.edu
     // }).appendTo($('#hc-container'));
 
     // Set string defaults, taking into account language
-    var instructions_start_top = 'First, set your computer volume to about 25% of maximum. ' +
+    var instructions_start = 'First, set your computer volume to about 25% of maximum. ' +
           'Press the button, then <strong>turn up the volume on your computer until the ' +
           'calibration noise is at a loud but comfortable level</strong>. ' +
           'Play the calibration sound as many times as you like.';


### PR DESCRIPTION
This "var" had been changed to instructions_start when we implemented Swedish. But it has not been changed for the default language. 